### PR TITLE
declare variables before using in for loops

### DIFF
--- a/CCDebugger.c
+++ b/CCDebugger.c
@@ -751,7 +751,8 @@ uint8_t cc_chipErase()
 uint8_t cc_updateInstructionTable( uint8_t newTable[16] )
 {
   // Copy table entries
-  for (uint8_t i=0; i<16; i++)
+  uint8_t i;
+  for (i=0; i<16; i++)
     instr[i] = newTable[i];
   // Return the new version
   return instr[INSTR_VERSION];

--- a/cc_read.c
+++ b/cc_read.c
@@ -25,13 +25,13 @@
 
 void writeHexLine(FILE * fic,uint8_t *buf, int len,int offset)
 {
-int i=0;
+  int i=0;
   for(i=0 ; i<len ; i++)
     if(buf[i] != 0xff) break;
   if(i==len) return;
   int sum=len+(offset&0xff)+((offset>>8)&0xff);
   fprintf(fic,":%02X%04X00",len,offset);
-  for(int i=0 ; i<len;i++)
+  for(i=0 ; i<len;i++)
   {
     fprintf(fic,"%02X",buf[i]);
     sum += buf[i];
@@ -51,7 +51,8 @@ void read1k(int bank,uint16_t offset,uint8_t * buf)
     res = cc_exec3(0x75, 0xC7, res); // MOV direct,#data
     // Setup DPTR
     cc_execi( 0x90, 0x8000+offset ); // MOV DPTR,#data16
-    for(int i=0 ; i<1024 ;i++)
+    int i;
+    for(i=0 ; i<1024 ;i++)
     {
       res = cc_exec  ( 0xE0 ); // MOVX A,@DPTR
       buf[i] = res;
@@ -87,14 +88,16 @@ int main(int argc,char **argv)
     offset=0;
     int len=0;
     uint8_t buf[17];
-    for ( uint16_t i=0 ; i<32 ; i++ )
+    uint16_t i;
+    for ( i=0 ; i<32 ; i++ )
     {
       do
       {
         read1k(bank,i*1024, buf1);
         read1k(bank,i*1024, buf2);
       } while(memcmp(buf1,buf2,1024));
-      for(uint16_t j=0 ; j<64 ; j++)
+      uint16_t j;
+      for(j=0 ; j<64 ; j++)
 	writeHexLine(ficout,buf1+j*16, 16,(bank&1)*32*1024+ i*1024+j*16);
       printf("\r reading %dk/256k",progress++);fflush(stdout);
     }

--- a/cc_write.c
+++ b/cc_write.c
@@ -40,7 +40,8 @@ uint8_t datas[2048];
 void readXDATA(uint16_t offset,uint8_t *bytes, int len)
 {
   cc_execi(0x90, offset ); //MOV DPTR,#data16
-  for ( int i=0 ; i<len;i++)
+  int i;
+  for (i=0 ; i<len;i++)
   {
     bytes[i] = cc_exec(0xE0);	//MOVX A,@DPTR
     cc_exec(0xA3);	// INC DPTR
@@ -50,7 +51,8 @@ void readXDATA(uint16_t offset,uint8_t *bytes, int len)
 void writeXDATA(uint16_t offset,uint8_t *bytes, int len)
 {
   cc_execi(0x90,offset); //MOV DPTR,#data16
-  for ( int i=0 ; i<len;i++)
+  int i;
+  for (i=0 ; i<len;i++)
   {
     cc_exec2(0x74,bytes[i]); // MOV A,#data
     cc_exec(0xF0);	//MOVX @DPTR,A
@@ -70,7 +72,8 @@ void readPage(int page,uint8_t *buf)
   uint32_t offset = ((page&0xf)<<11) + Pages[page].minoffset;
   // Setup DPTR
   cc_execi( 0x90, 0x8000+offset ); // MOV DPTR,#data16
-  for(int i=Pages[page].minoffset ; i<=Pages[page].maxoffset ;i++)
+  int i;
+  for(i=Pages[page].minoffset ; i<=Pages[page].maxoffset ;i++)
   {
     res = cc_exec  ( 0xE0 ); // MOVX A,@DPTR
     buf[i] = res;
@@ -88,7 +91,8 @@ int verifPage(int page)
     readPage(page,verif1);
     readPage(page,verif2);
   } while (memcmp(verif1,verif2,2048));
-  for(int i=Pages[page].minoffset ; i<=Pages[page].maxoffset ;i++)
+  int i;
+  for(i=Pages[page].minoffset ; i<=Pages[page].maxoffset ;i++)
   {
     if(verif1[i] != Pages[page].datas[i])
     {
@@ -167,7 +171,8 @@ int writePage(int page)
   // transfert de données en mode burst
   cc_write(0x80|( (len>>8)&0x7) );
   cc_write(len&0xff);
-  for(int i=0 ; i<len ;i++)
+  int i;
+  for(i=0 ; i<len ;i++)
     cc_write(Pages[page].datas[i+Pages[page].minoffset]);
   // wait DMA end :
   do
@@ -230,8 +235,8 @@ int main(int argc,char **argv)
   uint16_t ID;
   ID = cc_getChipID();
   printf("  ID = %04x.\n",ID);
-
-  for (int page=0 ; page<128 ; page++)
+  int page;
+  for (page=0 ; page<128 ; page++)
   {
     memset(Pages[page].datas,0xff,2048);
     Pages[page].minoffset=0xffff;
@@ -307,7 +312,7 @@ int main(int argc,char **argv)
   conf &= ~0x4;
   cc_setConfig(conf);
 
-  for (int page=0 ; page <= maxpage ; page++)
+  for (intage=0 ; page <= maxpage ; page++)
   {
     if(Pages[page].maxoffset<Pages[page].minoffset) continue;
     printf("\rwriting page %3d/%3d.",page+1,maxpage+1);
@@ -317,7 +322,7 @@ int main(int argc,char **argv)
   printf("\n");
   // lire les données et les vérifier
   int badPage=0;
-  for (int page=0 ; page <= maxpage ; page++)
+  for (page=0 ; page <= maxpage ; page++)
   {
     if(Pages[page].maxoffset<Pages[page].minoffset) continue;
     printf("\rverifying page %3d/%3d.",page+1,maxpage+1);


### PR DESCRIPTION
When trying to compile received errors like 

```
gcc -g -c CCDebugger.c
CCDebugger.c: In function ‘cc_updateInstructionTable’:
CCDebugger.c:754:3: error: ‘for’ loop initial declarations are only allowed in C99 mode
CCDebugger.c:754:3: note: use option -std=c99 or -std=gnu99 to compile your code
make: *** [CCDebugger.o] Error 1
```

Found for loops to be inconsistently using C99 style so changed all to pre-C99 style (https://stackoverflow.com/questions/29338206/error-for-loop-initial-declarations-are-only-allowed-in-c99-mode?rq=1)

Also discovered it's possible to flash a CC2531 using a RPI1 by changing the GPIO mappings to lower pins.