### PR TITLE
Unify pin number definition

### DIFF
--- a/CCDebugger.c
+++ b/CCDebugger.c
@@ -39,9 +39,6 @@
   /**
    * Local properties
    */
-  int       pinRST=24;
-  int       pinDC=28;
-  int       pinDD=29;
   uint8_t      errorFlag=0;
   uint8_t      ddIsOutput=false;
   uint8_t      inDebugMode=false;
@@ -70,7 +67,7 @@
 #define I_BURST_WRITE    15
 
 void cc_delay_calibrate( );
-int cc_init( int pRST, int pDC, int pDD )
+int cc_init()
 {
   if(wiringPiSetup() == -1){
     printf("no wiring pi detected\n");
@@ -78,17 +75,13 @@ int cc_init( int pRST, int pDC, int pDD )
   }
   cc_delay_calibrate();
 
-  pinRST=pRST;
-  pinDC=pDC;
-  pinDD=pDD;
-
   // Prepare CC Pins
-  pinMode(pinDC,        OUTPUT);
-  pinMode(pinDD,      OUTPUT);
-  pinMode(pinRST,       OUTPUT);
-  digitalWrite(pinDC,   LOW);
-  digitalWrite(pinDD, LOW);
-  digitalWrite(pinRST,  LOW);
+  pinMode(PIN_DC, OUTPUT);
+  pinMode(PIN_DD, OUTPUT);
+  pinMode(PIN_RST, OUTPUT);
+  digitalWrite(PIN_DC, LOW);
+  digitalWrite(PIN_DD, LOW);
+  digitalWrite(PIN_RST, LOW);
 
   // Prepare default direction
   cc_setDDDirection(INPUT);
@@ -129,12 +122,12 @@ void cc_setActive( uint8_t on )
   if (on) {
 
     // Prepare CC Pins
-    pinMode(pinDC,        OUTPUT);
-    pinMode(pinDD,      OUTPUT);
-    pinMode(pinRST,       OUTPUT);
-    digitalWrite(pinDC,   LOW);
-    digitalWrite(pinDD, LOW);
-    digitalWrite(pinRST,  LOW);
+    pinMode(PIN_DC, OUTPUT);
+    pinMode(PIN_DD, OUTPUT);
+    pinMode(PIN_RST, OUTPUT);
+    digitalWrite(PIN_DC, LOW);
+    digitalWrite(PIN_DD, LOW);
+    digitalWrite(PIN_RST, LOW);
 
     // Default direction is INPUT
     cc_setDDDirection(INPUT);
@@ -146,12 +139,12 @@ void cc_setActive( uint8_t on )
       cc_exit();
 
     // Put everything in inactive mode
-    pinMode(pinDC,        INPUT);
-    pinMode(pinDD,      INPUT);
-    pinMode(pinRST,       INPUT);
-    digitalWrite(pinDC,   LOW);
-    digitalWrite(pinDD, LOW);
-    digitalWrite(pinRST,  LOW);
+    pinMode(PIN_DC, INPUT);
+    pinMode(PIN_DD, INPUT);
+    pinMode(PIN_RST, INPUT);
+    digitalWrite(PIN_DC, LOW);
+    digitalWrite(PIN_DD, LOW);
+    digitalWrite(PIN_RST, LOW);
 
   }
 }
@@ -212,17 +205,17 @@ uint8_t cc_enter()
   errorFlag = CC_ERROR_NONE;
 
   // Enter debug mode
-  digitalWrite(pinRST, LOW);
+  digitalWrite(PIN_RST, LOW);
   cc_delay(200);
-  digitalWrite(pinDC, HIGH);
+  digitalWrite(PIN_DC, HIGH);
   cc_delay(3);
-  digitalWrite(pinDC, LOW);
+  digitalWrite(PIN_DC, LOW);
   cc_delay(3);
-  digitalWrite(pinDC, HIGH);
+  digitalWrite(PIN_DC, HIGH);
   cc_delay(3);
-  digitalWrite(pinDC, LOW);
+  digitalWrite(PIN_DC, LOW);
   cc_delay(4);
-  digitalWrite(pinRST, HIGH);
+  digitalWrite(PIN_RST, HIGH);
   cc_delay(200);
 
   // We are now in debug mode
@@ -265,14 +258,14 @@ uint8_t cc_write( uint8_t data )
       digitalWrite(pinDD, LOW);
 
     // Place clock on high (other end reads data)
-    digitalWrite(pinDC, HIGH);
+    digitalWrite(PIN_DC, HIGH);
 
     // Shift & Delay
     data <<= 1;
     cc_delay(2);
 
     // Place clock down
-    digitalWrite(pinDC, LOW);
+    digitalWrite(PIN_DC, LOW);
     cc_delay(2);
 
   }
@@ -310,9 +303,9 @@ uint8_t cc_switchRead(uint8_t maxWaitCycles)
 
     // Do 8 clock cycles
     for (cnt = 8; cnt; cnt--) {
-      digitalWrite(pinDC, HIGH);
+      digitalWrite(PIN_DC, HIGH);
       cc_delay(2);
-      digitalWrite(pinDC, LOW);
+      digitalWrite(PIN_DC, LOW);
       cc_delay(2);
     }
 
@@ -367,7 +360,7 @@ uint8_t cc_read()
 
   // Send 8 clock pulses if we are HIGH
   for (cnt = 8; cnt; cnt--) {
-    digitalWrite(pinDC, HIGH);
+    digitalWrite(PIN_DC, HIGH);
     cc_delay(2);
 
     // Shift and read
@@ -375,7 +368,7 @@ uint8_t cc_read()
     if (digitalRead(pinDD) == HIGH)
       data |= 0x01;
 
-    digitalWrite(pinDC, LOW);
+    digitalWrite(PIN_DC, LOW);
     cc_delay(2);
   }
 
@@ -395,13 +388,13 @@ void cc_setDDDirection( uint8_t direction )
 
   // Handle new direction
   if (ddIsOutput) {
-    digitalWrite(pinDD, LOW); // Disable pull-up
-    pinMode(pinDD, OUTPUT);   // Enable output
-    digitalWrite(pinDD, LOW); // Switch to low
+    digitalWrite(PIN_DD, LOW); // Disable pull-up
+    pinMode(PIN_DD, OUTPUT);   // Enable output
+    digitalWrite(PIN_DD, LOW); // Switch to low
   } else {
-    digitalWrite(pinDD, LOW); // Disable pull-up
-    pinMode(pinDD, INPUT);    // Disable output
-    digitalWrite(pinDD, LOW); // Don't use output pull-up
+    digitalWrite(PIN_DD, LOW); // Disable pull-up
+    pinMode(PIN_DD, INPUT);    // Disable output
+    digitalWrite(PIN_DD, LOW); // Don't use output pull-up
   }
 
 }

--- a/CCDebugger.h
+++ b/CCDebugger.h
@@ -7,8 +7,11 @@
 #define CC_ERROR_NOT_DEBUGGING  2
 #define CC_ERROR_NOT_WIRED      3
 
+#define PIN_RST 24
+#define PIN_DC  27
+#define PIN_DD  28
 
-  int cc_init( int pinRST, int pinDC, int pinDD );
+  int cc_init();
   void cc_delay( unsigned char d );
 
   uint8_t cc_error();

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Connect the following pins of the debug port to the GPIO port :
 
 and insert the usb dongle in a port.
 
+To change pin numbers, edit `CCDebugger.h` file and run `make`.
+
 A downloader cable CC and 4 Dupont line Female to Female are perfect for this purpose :
 
 ![](https://github.com/jmichault/files/blob/master/Raspberry-CC2531.jpg)

--- a/cc_chipid.c
+++ b/cc_chipid.c
@@ -26,7 +26,7 @@
 int main()
 {
   // initialize GPIO and debugger
-  cc_init(24,27,28);
+  cc_init();
   // enter debug mode
   cc_enter();
   // get ChipID :

--- a/cc_erase.c
+++ b/cc_erase.c
@@ -26,7 +26,7 @@
 int main()
 {
   // initialize GPIO and debugger
-  cc_init(24,27,28);
+  cc_init();
   // enter debug mode
   cc_enter();
   // get ChipID :

--- a/cc_read.c
+++ b/cc_read.c
@@ -65,7 +65,7 @@ int main(int argc,char **argv)
   FILE * ficout = fopen(argv[1],"w");
   if(!ficout) { fprintf(stderr," Can't open file %s.\n",argv[1]); exit(1); }
   //  initialize GPIO ports
-  cc_init(24,27,28);
+  cc_init();
   // enter debug mode
   cc_enter();
   // get ChipID :

--- a/cc_write.c
+++ b/cc_write.c
@@ -223,7 +223,7 @@ int main(int argc,char **argv)
  FILE * ficin = fopen(argv[1],"r");
   if(!ficin) { fprintf(stderr," Can't open file %s.\n",argv[1]); exit(1); }
   // on initialise les ports GPIO et le debugger
-  cc_init(24,27,28);
+  cc_init();
   // entrée en mode debug
   cc_enter();
   // envoi de la commande getChipID :


### PR DESCRIPTION
Pin numbers were hard-wired in each `cc_*.c` file. This change unifies the pin numbers to the header file definitions as user usually needs to use more than one executable on particular device, and this setting has to be consistent. Also, the default values in the `CCDebugger.c` were different from the used and documented values.